### PR TITLE
Fix: screen reload navigation using useSafeBack hook (#63)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3777,7 +3777,6 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -5666,7 +5665,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -8952,6 +8950,13 @@
       "resolved": "https://registry.npmjs.org/jimp-compact/-/jimp-compact-0.16.1.tgz",
       "integrity": "sha512-dZ6Ra7u1G8c4Letq/B5EzAxj4tLFHL+cGtdpR+PVm4yzPDj+lCk+AbivWt1eOM+ikzkowtyV7qSqX6qr3t71Ww==",
       "license": "MIT"
+    },
+    "node_modules/jquery": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
+      "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/src/app/CalendarView.tsx
+++ b/src/app/CalendarView.tsx
@@ -3,15 +3,18 @@ import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import { WeeklyView as CalendarComponent } from '../components/CalendarView';
 import { useApp } from '../contexts/AppContext';
+import { useSafeBack } from '../hooks/use-Safe-Back';
+
 
 export default function CalendarViewScreen() {
   const router = useRouter();
   const { tasks, settings, addTask, toggleTask, updateTask, deleteTask, triggerConfetti } = useApp();
+  const handleBack = useSafeBack();
 
   return (
     <View style={styles.container}>
       <CalendarComponent
-        onNavigateBack={() => router.back()}
+        onNavigateBack={handleBack}
         onNavigateSettings={() => router.push('/Settings')}
         tasks={tasks}
         onToggleTask={toggleTask}

--- a/src/app/OneThingMode.tsx
+++ b/src/app/OneThingMode.tsx
@@ -4,15 +4,18 @@ import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import { OneThingMode as OneThingComponent } from '../components/OneThingMode';
 import { useApp } from '../contexts/AppContext';
+import { useSafeBack } from '../hooks/use-Safe-Back';
+
 
 export default function OneThingModeScreen() {
   const router = useRouter();
   const { tasks, settings, toggleTask, triggerConfetti } = useApp();
+  const handleBack = useSafeBack();
 
   return (
     <View style={styles.container}>
       <OneThingComponent
-        onNavigateBack={() => router.back()}
+        onNavigateBack={handleBack}
         tasks={tasks}
         onToggleTask={toggleTask}
         settings={settings}

--- a/src/app/Settings.tsx
+++ b/src/app/Settings.tsx
@@ -4,15 +4,18 @@ import { View, StyleSheet } from 'react-native';
 import { useRouter } from 'expo-router';
 import { Settings as SettingsComponent } from '../components/Settings';
 import { useApp } from '../contexts/AppContext';
+import { useSafeBack } from '../hooks/use-Safe-Back';
+
 
 export default function SettingsScreen() {
   const router = useRouter();
   const { settings, updateSettings } = useApp();
+  const handleBack = useSafeBack();
 
   return (
     <View style={styles.container}>
       <SettingsComponent
-        onNavigateBack={() => router.back()}
+        onNavigateBack={handleBack}
         settings={settings}
         onUpdateSettings={updateSettings}
       />

--- a/src/hooks/use-Safe-Back.ts
+++ b/src/hooks/use-Safe-Back.ts
@@ -1,0 +1,14 @@
+// src/hooks/use-Safe-Back.ts
+import { useRouter } from 'expo-router';
+
+export function useSafeBack() {
+  const router = useRouter();
+
+  return () => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace('/');
+    }
+  };
+}


### PR DESCRIPTION
Fixes the screen reload issue where custom back buttons would fail after a reload, leaving the user on the current screen instead of navigating to the root (index) screen. 

Changes Made:

- Created a reusable use-Safe-Back hook for safe navigation.
- Updated the following screens to use use-Safe-Back.
- Settings.tsx, OneThingMode.tsx, and CalendarView.tsx
- Removed all inline router.back() calls to prevent reload-related navigation bugs.
- Ensured normal back navigation works when history exists, and reloading or deep-linking safely navigates to the root screen.

Testing:

- Verified normal navigation back works correctly.
- Verified that reloading on any of the affected screens navigates back to the root screen safely.
- Verified deep-link scenarios still behave correctly.

Notes:

- No changes were required in _layout.tsx or index.tsx.
- This hook can be reused for any screen that needs a safe "back" behavior in the future.