### PR TITLE
Fixed One-Thing-Mode Timer Bug

### DIFF
--- a/src/components/OneThingMode.tsx
+++ b/src/components/OneThingMode.tsx
@@ -218,7 +218,7 @@ export function OneThingMode({
 
   const resetTimer = () => {
     setIsRunning(false);
-    setTimeInSeconds(0);
+    setTimeInSeconds(settings.defaultTimerMinutes * 60); // use user’s allotted time instead of 0
     setHasCompleted(false);
     setShownIntervals(new Set());
     if (notificationId) {
@@ -545,7 +545,10 @@ export function OneThingMode({
                   ]}
                   onPress={() => {
                     setSelectedTaskId(task.id);
-                    resetTimer();
+                    setTimeInSeconds(settings.defaultTimerMinutes * 60); // always show allotted time
+                    setIsRunning(false);
+                    setHasCompleted(false);
+                    setShownIntervals(new Set());
                   }}
                   activeOpacity={0.7}
                 >


### PR DESCRIPTION
Closes #136 

Previously, when a user switched between tasks in One Thing Mode, the timer would reset to 0 and only show the correct time after clicking Start. This was confusing because the timer did not display the time the user had allotted for the task.

## Changes

- Updated onPress handler for task selection to initialize timeInSeconds to settings.defaultTimerMinutes * 60
- Updated resetTimer() to set the timer to the allotted time instead of 0

## Impact

- Timer now correctly reflects the user’s chosen duration when switching tasks

